### PR TITLE
5.2.1 Permissions

### DIFF
--- a/NIM-permissions/nginx-instance-manager-scc-binder.yaml
+++ b/NIM-permissions/nginx-instance-manager-scc-binder.yaml
@@ -1,0 +1,13 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nginx-instance-manager-scc-binder
+rules:
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - nms-restricted-v2-scc

--- a/NIM-permissions/nms-restricted-v2-scc.yaml
+++ b/NIM-permissions/nms-restricted-v2-scc.yaml
@@ -1,0 +1,42 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: 'nms-restricted-v2-scc'
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - NET_BIND_SERVICE
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 101
+      max: 101
+    - min: 1000
+      max: 1000
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMin: 101
+  uidRangeMax: 1000
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: []
+groups: []
+volumes:
+  - configMap
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/permissions/nginx-ingress-cluster-viewer.yaml
+++ b/permissions/nginx-ingress-cluster-viewer.yaml
@@ -10,6 +10,13 @@ rules:
   verbs:
   - list
   - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
All the changed permissions needed in the 3.7.0 --> 5.2.1 version update along with the NIM-permissions needed to manage the licenses of the IngressControllers